### PR TITLE
Adding ability to recognize more cities

### DIFF
--- a/geotext/geotext.py
+++ b/geotext/geotext.py
@@ -103,7 +103,7 @@ class GeoText(object):
     index = build_index()
 
     def __init__(self, text):
-        city_regex = r"[A-Z]+[a-z]*(?:[ '-][A-Z]+[a-z]*)*"
+        city_regex = r"[A-Z]+[a-zà-ú]*(?:[ '-][A-Z]+[a-zà-ú]*)*"
         candidates = re.findall(city_regex, text)
         self.countries = [each for each in candidates
                           if each.lower() in self.index.countries]


### PR DESCRIPTION
Problem: Brazilian cities like "São Paulo", "Carapicuíba" and other was not passing on old "city_regex".

Example using last version:

```
>>> text = "São Paulo é a capital do estado de São Paulo. As cidades de Baru
erí e Carapicuíba fazem parte da Grade São Paulo. O Rio de Janeiro continua
lindo. No carnaval eu vou para Salvador. No reveillon eu quero ir para Santo
s."
>>> old_result = GeoText(text)
>>> old_result.cities
['Salvador', 'Santos']
>>>
```

Considering the same text, using this "new" regex we have:

```
>>> result.cities
['S\xc3\xa3o Paulo', 'S\xc3\xa3o Paulo', 'As', 'Baruer\xc3\xad', 'Carapicu\x
c3\xadba', 'Grade S\xc3\xa3o Paulo', 'O Rio', 'Janeiro', 'No', 'Salvador', '
No', 'Santos']
```

I think this change can be useful to recognize other cities in the world.